### PR TITLE
v1.0.2 release candidate

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,17 +1,26 @@
 [
     {
-        "caption": "FontSizePerView: Increase View Font Size",
+        "caption": "Font Size Per View: Increase View Font Size",
         "command": "adjust_font_size_per_view",
         "args": {"delta": 1}
     },
     {
-        "caption": "FontSizePerView: Decrease View Font Size",
+        "caption": "Font Size Per View: Decrease View Font Size",
         "command": "adjust_font_size_per_view",
         "args": {"delta": -1}
     },
     {
-        "caption": "FontSizePerView: Reset View Font Size",
+        "caption": "Font Size Per View: Reset View Font Size",
         "command": "adjust_font_size_per_view",
         "args": {}
+    },
+    {
+        "caption": "Font Size Per View: Open Key Binding Settings",
+        "command": "edit_settings",
+        "args": {
+            "base_file": "${packages}/Font Size Per View/Default.sublime-keymap",
+            "user_file": "${packages}/User/Default (${platform}).sublime-keymap",
+            "default": "[\n\t$0\n]\n",
+        }
     },
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -49,7 +49,7 @@
                 "caption": "Key Bindings",
                 "command": "edit_settings",
                 "args": {
-                  "base_file": "${packages}/FontSizePerView/Default.sublime-keymap",
+                  "base_file": "${packages}/Font Size Per View/Default.sublime-keymap",
                   "user_file": "${packages}/User/Default (${platform}).sublime-keymap",
                   "default": "[\n\t$0\n]\n",
                 }

--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ $ git clone https://github.com/m-bartlett/SublimeFontSizePerView "~/Library/Appl
 ### Command Palette
 
 Using the command palette, query for any of these commands:
-- `FontSizePerView: Increase View Font Size`
-- `FontSizePerView: Decrease View Font Size`
-- `FontSizePerView: Reset View Font Size`
+- `Font Size Per View: Increase View Font Size`
+- `Font Size Per View: Decrease View Font Size`
+- `Font Size Per View: Reset View Font Size`
 
 **Note**: the `Reset View Font Size` command reads the `font_size` setting in your global user settings in `~/.config/sublime-text/Packages/User/Preferences.sublime-settings` to determine what font size to reset the view to.
 
 ### Default Keybinds
 
-**Note**: These keybinds are commented out initially. To access a view to quickly edit your keybinding settings, click the context menu option `Preferences` > `Package Settings` > `FontSizePerView` > `Key Bindings`.
+**Note**: These keybinds are commented out initially. To access a view to quickly edit your keybinding settings, click the context menu option `Preferences` > `Package Settings` > `Font Size Per View` > `Key Bindings`.
 
 - `ctrl+alt+=` will call `adjust_font_size_per_view` with args `{"delta": 1}` which increases the active view's font size by 1 pt.
 - `ctrl+alt+-` will call `adjust_font_size_per_view` with args `{"delta": -1}` which decreases the active view's font size by 1 pt.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Sublime Text plugin to support adjusting the font size in each view individual
 
 1. Open the command palette in Sublime Text (ctrl+shift+p by default).
 1. Search for `Package Control: Install Package` and hit enter to execute the command.
-1. Search for`Font Size Per View` in the list of displayed packages, and hit enter once it is selected to install the plugin.
+1. Search for`Font Size Per View` in the list of displayed packages, then hit enter once it is focused to install the plugin.
 
 The plugin will now be installed. 
 
@@ -24,11 +24,22 @@ The plugin will now be installed.
 
 ### Manual
 
-Clone this repository into `~/.config/sublime-text/Packages/` named as `FontSizePerView`.
+#### Linux/Windows
+
+Clone this repository into `~/.config/sublime-text/Packages/` named as `Font Size Per View`.
 
 For example:
 ```console
-$ git clone https://github.com/m-bartlett/SublimeFontSizePerView ~/.config/sublime-text/Packages/FontSizePerView
+$ git clone https://github.com/m-bartlett/SublimeFontSizePerView "~/.config/sublime-text/Packages/Font Size Per View"
+```
+
+#### MacOS
+
+Clone this repository into `~/Library/Application Support/Sublime Text/Packages/` named as `Font Size Per View`.
+
+For example:
+```console
+$ git clone https://github.com/m-bartlett/SublimeFontSizePerView "~/Library/Application Support/Sublime Text/Packages/Font Size Per View"
 ```
 
 ## Usage

--- a/font-size-per-view.py
+++ b/font-size-per-view.py
@@ -13,7 +13,7 @@ class AdjustFontSizePerViewCommand(sublime_plugin.TextCommand):
 
 
     def set_font_size(self, font_size):
-        self.view.run_command('set_setting', {"setting": "font_size", "value": font_size});
+        self.view.run_command('set_setting', {"setting": "font_size", "value": font_size})
 
 
     def add_font_size(self, delta):


### PR DESCRIPTION
Changelog:
- Fix path bugs introduced by package name getting spaces when merged into the Package Control channel
- Change command palette command prefix to reflect the finalized package name with spaces
- Add command palette entry to open keymap settings (same as menu-bar entry)
- Correct instructions in README, and add MacOS-specific instructions
- Minor code syntax improvements